### PR TITLE
fix: make robust c++ type deduce

### DIFF
--- a/cxx-async/include/rust/cxx_async.h
+++ b/cxx-async/include/rust/cxx_async.h
@@ -152,12 +152,6 @@
               std::move(other)) {}                                          \
   };                                                                        \
   CXXASYNC_CLOSE_NAMESPACE(__VA_ARGS__)                                     \
-  template <typename... Args>                                               \
-  struct ::rust::async::std_coroutine::                                     \
-      coroutine_traits<CXXASYNC_JOIN_NAMESPACE(__VA_ARGS__), Args...> {     \
-    using promise_type =                                                    \
-        ::rust::async::RustPromise<CXXASYNC_JOIN_NAMESPACE(__VA_ARGS__)>;   \
-  };
 
 #define CXXASYNC_DEFINE_FUTURE(type, ...) \
   CXXASYNC_DEFINE_FUTURE_OR_STREAM(type, type, __VA_ARGS__)


### PR DESCRIPTION
Completely remove template specialization code: Modern C++ compilers (supporting C++20 coroutines) can automatically infer promise_type. Rely on automatic lookup mechanism: As long as the RustPromise class defines the correct coroutine interface, the compiler can find it.

FIX: Avoid problems with complex macro generation and template specialization

Why does this solution work?
- C++20 coroutines will automatically look for the promise_type of the return type
- The RustPromise class has implemented all interfaces required for coroutine promises
- Avoid error-prone template specialization and macro generation
- Fully compliant with the C++20 coroutine specification