### PR TITLE
fix: handle default case in RustFutureReceiver termination in MSVC

### DIFF
--- a/cxx-async/include/rust/cxx_async.h
+++ b/cxx-async/include/rust/cxx_async.h
@@ -551,6 +551,9 @@ class RustFutureReceiver {
         // TODO(pcwalton): Handle C++ consuming Rust streams.
         CXXASYNC_ASSERT(false);
         std::terminate();
+      default:
+        CXXASYNC_ASSERT(false);
+        std::terminate();
     }
   }
 };


### PR DESCRIPTION
When i was using cxx & cxx-async in unreal engine on windows

MSVC complains an error and requires a `default` control path when switch case enums

<img width="2032" height="150" alt="image" src="https://github.com/user-attachments/assets/9b181627-1b16-45bd-abe3-32b188ef620d" />
