### PR TITLE
fix: clang -Wignored-qualifiers

### DIFF
--- a/cxx-async/include/rust/cxx_async.h
+++ b/cxx-async/include/rust/cxx_async.h
@@ -136,7 +136,7 @@
             __VA_ARGS__)> {                                                 \
     typedef type YieldResult;                                               \
     typedef final_result_type FinalResult;                                  \
-    static const auto vtable() {                                            \
+    static auto vtable() {                                                  \
       return CXXASYNC_CONCAT_3(                                             \
           cxxasync_, CXXASYNC_JOIN_DOLLAR(__VA_ARGS__), _vtable());         \
     }                                                                       \


### PR DESCRIPTION
`CXXASYNC_CONCAT_3` returns a pointer so `const` is useless.