### PR TITLE
fix: upgrade to the minimum required cxx-async-macro version

### DIFF
--- a/cxx-async/Cargo.toml
+++ b/cxx-async/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = "1"
 
 # CXX related dependencies
 cxx = { version = "1", features = ["c++20"] }
-cxx-async-macro = { version = "0.1.1", path = "../macro" }
+cxx-async-macro = { version = "0.1.3", path = "../macro" }
 link-cplusplus = { version = "1" }
 
 # Async related dependencies


### PR DESCRIPTION
`cxx-async-macro` v0.1.2 requires `cxx-async::unsafe_pinned` which has been removed in the commit [`1416f54`](https://github.com/pcwalton/cxx-async/commit/1416f54bccced09c944e4de1ca51e4e74dbee8ca). It is not compatible with the latest `cxx-async`.